### PR TITLE
Adds .settings file, routing, local docker registry and nice colors

### DIFF
--- a/.settings
+++ b/.settings
@@ -16,7 +16,7 @@ start_registry=true
 start_dns=true
 start_ui=true
 
-# helpers
+# helpers todo this should be somewhere else; or rename the settings file into 'common.sh'
 function check_rc {
 	success_message=$1
 	error_message=$2

--- a/.settings
+++ b/.settings
@@ -1,0 +1,28 @@
+# colors
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+reset=$(tput sgr0)
+
+# icons
+checkmark="\xE2\x9C\x93"
+warning="\xE2\x9A\xA0"
+error="\xE2\x9C\x97"
+
+# startup settings
+port_forward=true
+add_route=true
+start_registry=true
+start_dns=true
+start_ui=true
+
+# helpers
+function check_rc {
+	success_message=$1
+	error_message=$2
+	if [ $? -eq 0 ]; then
+		printf "\n${green}   ${checkmark} $success_message ${reset}\n\n"
+	else
+		printf "\n${red}   ${error} $error_message ${reset}\n\n"
+	fi
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ Then, launch the Kubernetes cluster in boot2docker via Docker Machine:
 
 The script will set up port forwarding so that you can use kubectl locally without having to ssh into boot2docker. The default password for the boot2docker docker user is `tcuser`.
 
+## Controlling Addons (DNS, UI)
+You can use the `.settings` file to tell the `kube-up.sh` script which additional services to start. The default is
+to start all addons:
+
+```
+# startup settings
+port_forward=true
+add_route=true
+start_registry=true
+start_dns=true
+start_ui=true
+```
+
+- `port_forward` will setup the SSH tunnel for accessing the API server via `kubectl`
+- `add_route` will create a custom routing entry to enable local name resolution via the configured cluster DNS
+- `start_registry` will start a private docker registry (can be used to make local images available to k8s)
+- `start_dns` will start skydns and the kube2sky bridge
+- `start_ui` will start the k8s UI
+
 ## Checking if Kubernetes Is Running
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -28,26 +28,23 @@ Then, launch the Kubernetes cluster in boot2docker via Docker Machine:
 ./kube-up.sh
 ```
 
-The script will set up port forwarding so that you can use kubectl locally without having to ssh into boot2docker. The default password for the boot2docker docker user is `tcuser`.
+The script will set up port forwarding so that you can use kubectl locally without having to ssh into boot2docker.
 
 ## Controlling Addons (DNS, UI)
-You can use the `.settings` file to tell the `kube-up.sh` script which additional services to start. The default is
-to start all addons:
+You can use the the following options to disable specific additional services. The default is
+to start all addons, __except__ the local Docker Registry:
 
 ```
-# startup settings
-port_forward=true
-add_route=true
-start_registry=true
-start_dns=true
-start_ui=true
+Usage: kube-up.sh [-fndursh]
+Available options are:
+	-f  disable forward to port 8080 on docker machine (required for kubectl)
+	-n  disable adding route to enable local name resolution via skyDNS
+	-d  disable skyDNS
+	-u  disable kube-ui
+	-r  start local docker registry
+	-h  show this help text
+	-s  silent mode
 ```
-
-- `port_forward` will setup the SSH tunnel for accessing the API server via `kubectl`
-- `add_route` will create a custom routing entry to enable local name resolution via the configured cluster DNS
-- `start_registry` will start a private docker registry (can be used to make local images available to k8s)
-- `start_dns` will start skydns and the kube2sky bridge
-- `start_ui` will start the k8s UI
 
 ## Checking if Kubernetes Is Running
 

--- a/common.sh
+++ b/common.sh
@@ -9,13 +9,6 @@ checkmark="\xE2\x9C\x93"
 warning="\xE2\x9A\xA0"
 error="\xE2\x9C\x97"
 
-# startup settings
-port_forward=true
-add_route=true
-start_registry=true
-start_dns=true
-start_ui=true
-
 # helpers todo this should be somewhere else; or rename the settings file into 'common.sh'
 function check_rc {
 	success_message=$1

--- a/common.sh
+++ b/common.sh
@@ -19,3 +19,6 @@ function check_rc {
 		printf "\n${red}   ${error} $error_message ${reset}\n\n"
 	fi
 }
+
+
+

--- a/kube-down.sh
+++ b/kube-down.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-echo "Stopping replication controllers, services and pods..."
-kubectl stop replicationcontrollers,services,pods --all
+
+source .settings
+
+printf "${yellow}Stopping replication controllers, services and pods...${reset}\n"
+
+kubectl stop replicationcontrollers,services,pods --all &> /dev/null
 if [ $? != 0 ]; then
-    echo "Kubernetes already down?"
+    printf "\n${yellow}   ${warning} Cannot contact API server. Kubernetes already down? ${reset}\n\n"
 fi
 
 cd kubernetes
@@ -14,7 +18,13 @@ fi
 k8s_containers=`docker ps -a -f "name=k8s_" -q`
 
 if [ ! -z "$k8s_containers" ]; then
-    echo "Stopping and removing all other containers that were started by Kubernetes..."
+    printf "${yellow}Stopping and removing all other containers that were started by Kubernetes...${reset}\n"
     docker stop $k8s_containers
     docker rm -f -v $k8s_containers
 fi
+
+cd ../scripts 
+if [ -n "$start_registry" ]; then
+	./start-docker-registry.sh stop
+fi
+

--- a/kube-down.sh
+++ b/kube-down.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source .settings
+source ./common.sh
 
 printf "${yellow}Stopping replication controllers, services and pods...${reset}\n"
 
@@ -23,7 +23,7 @@ if [ ! -z "$k8s_containers" ]; then
     docker rm -f -v $k8s_containers
 fi
 
-cd ../scripts 
+cd ../scripts
 if [ -n "$start_registry" ]; then
 	./start-docker-registry.sh stop
 fi

--- a/kube-up.sh
+++ b/kube-up.sh
@@ -9,21 +9,19 @@ start_ui=0
 start_registry=0
 silent=0
 
-USAGE="Usage: $(basename $0) [-fndursh]"
-
 read -r -d '' HELP_TEXT <<'USAGE_TEXT'
+Usage: kube-up.sh [-fndursh]
 Available options are:
-	-f  do NOT forward port 8080 to docker machine (required for kubectl)
-	-n  add route to enable local name resolution via skyDNS
-	-d  start skyDNS
-	-u  start kube-ui
+	-f  disable forward to port 8080 on docker machine (required for kubectl)
+	-n  disable adding route to enable local name resolution via skyDNS
+	-d  disable skyDNS
+	-u  disable kube-ui
 	-r  start local docker registry
-	-h  show this help text
 	-s  silent mode
+	-h  show this help text
 USAGE_TEXT
 
 function show_help {
-	echo "$USAGE"
 	echo "$HELP_TEXT"
     exit 0
 }
@@ -36,11 +34,13 @@ while getopts "fndush?:" opt; do
         ;;
     f)  port_forward=0
         ;;
-    n)  add_route=1
+    n)  add_route=0
         ;;
-	d)  start_dns=1
+	d)  start_dns=0
 		;;
-	u)  start_ui=1
+	u)  start_ui=0
+		;;
+	r)  start_registry=0
 		;;
 	s)  silent=1
 		;;

--- a/kube-up.sh
+++ b/kube-up.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+source .settings
 
 require_command_exists() {
-    command -v "$1" >/dev/null 2>&1 || { echo "$1 is required but is not installed. Aborting." >&2; exit 1; }
+    command -v "$1" >/dev/null 2>&1 || { printf "${red}$1 is required but is not installed. Aborting.\n${reset}" >&2; exit 1; }
 }
 
 require_command_exists kubectl
@@ -10,19 +11,37 @@ require_command_exists docker-compose
 
 docker info > /dev/null
 if [ $? != 0 ]; then
-    echo "A running Docker engine is required. Is your Docker host up?"
+    printf "${red}A running Docker engine is required. Is your Docker host up?${reset}\n"
     exit 1
 fi
 
+printf "${yellow}Composing k8s cluster...${reset}\n"
 cd kubernetes
 docker-compose up -d
 
 cd ../scripts
 
+echo
+
 if [ $(command -v docker-machine) ] &&  [ ! -z "$(docker-machine active)" ]; then
-    ./docker-machine-port-forwarding.sh
+    if [ ! -z ${port_forward} ]; then
+		./docker-machine-port-forwarding.sh
+	fi
+    if [ ! -z ${add_route} ]; then
+		./docker-machine-add-route.sh
+	fi
 fi
 
 ./wait-for-kubernetes.sh
-./activate-dns.sh
-./activate-kube-ui.sh
+
+if [ -n "$start_dns" ]; then 
+	./activate-dns.sh
+fi
+
+if [ -n "$start_ui" ]; then
+	./activate-kube-ui.sh
+fi
+
+if [ -n "$start_registry" ]; then
+	./start-docker-registry.sh start
+fi

--- a/kube-up.sh
+++ b/kube-up.sh
@@ -3,9 +3,9 @@ source ./common.sh
 
 # CLI arguments
 port_forward=1
-add_route=0
-start_dns=0
-start_ui=0
+add_route=1
+start_dns=1
+start_ui=1
 start_registry=0
 silent=0
 
@@ -26,7 +26,7 @@ function show_help {
     exit 0
 }
 
-while getopts "fndush?:" opt; do
+while getopts "fndushr?:" opt; do
     case "$opt" in
     h|\?)
         show_help
@@ -40,7 +40,7 @@ while getopts "fndush?:" opt; do
 		;;
 	u)  start_ui=0
 		;;
-	r)  start_registry=0
+	r)  start_registry=1
 		;;
 	s)  silent=1
 		;;

--- a/kube-up.sh
+++ b/kube-up.sh
@@ -1,5 +1,54 @@
 #!/bin/bash
-source .settings
+source ./common.sh
+
+# CLI arguments
+port_forward=1
+add_route=0
+start_dns=0
+start_ui=0
+start_registry=0
+silent=0
+
+USAGE="Usage: $(basename $0) [-fndursh]"
+
+read -r -d '' HELP_TEXT <<'USAGE_TEXT'
+Available options are:
+	-f  do NOT forward port 8080 to docker machine (required for kubectl)
+	-n  add route to enable local name resolution via skyDNS
+	-d  start skyDNS
+	-u  start kube-ui
+	-r  start local docker registry
+	-h  show this help text
+	-s  silent mode
+USAGE_TEXT
+
+function show_help {
+	echo "$USAGE"
+	echo "$HELP_TEXT"
+    exit 0
+}
+
+while getopts "fndush?:" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    f)  port_forward=0
+        ;;
+    n)  add_route=1
+        ;;
+	d)  start_dns=1
+		;;
+	u)  start_ui=1
+		;;
+	s)  silent=1
+		;;
+    esac
+done
+
+#echo "port_forward='$port_forward', add_route='$add_route', start_dns: '$start_dns'"
+
 
 require_command_exists() {
     command -v "$1" >/dev/null 2>&1 || { printf "${red}$1 is required but is not installed. Aborting.\n${reset}" >&2; exit 1; }
@@ -24,24 +73,24 @@ cd ../scripts
 echo
 
 if [ $(command -v docker-machine) ] &&  [ ! -z "$(docker-machine active)" ]; then
-    if [ ! -z ${port_forward} ]; then
+    if [ "$port_forward" -eq 1 ]; then
 		./docker-machine-port-forwarding.sh
 	fi
-    if [ ! -z ${add_route} ]; then
+    if [ "$add_route" -eq 1 ]; then
 		./docker-machine-add-route.sh
 	fi
 fi
 
 ./wait-for-kubernetes.sh
 
-if [ -n "$start_dns" ]; then 
+if [ "$start_dns" -eq 1 ]; then
 	./activate-dns.sh
 fi
 
-if [ -n "$start_ui" ]; then
+if [ "$start_ui" -eq 1 ]; then
 	./activate-kube-ui.sh
 fi
 
-if [ -n "$start_registry" ]; then
+if [ "$start_registry" -eq 1 ]; then
 	./start-docker-registry.sh start
 fi

--- a/kubernetes/docker-compose.yml
+++ b/kubernetes/docker-compose.yml
@@ -25,9 +25,9 @@ proxy:
 kube2sky:
   image: gcr.io/google_containers/kube2sky:1.11
   net: host
-  command: ['--kube_master_url=http://127.0.0.1:8080', '--domain=cluster.local']
+  command: ['--kube_master_url=http://127.0.0.1:8080', '--domain=cluster.local', '--v=2']
 
 skydns:
   image: gcr.io/google_containers/skydns:2015-03-11-001
   net: host
-  command: ['--machines=http://localhost:4001', '--addr=0.0.0.0:53', '--domain=cluster.local']
+  command: ['--machines=http://localhost:4001', '--addr=0.0.0.0:53', '--domain=cluster.local', '-nameservers=8.8.8.8:53,8.8.4.4:53']

--- a/scripts/activate-dns.sh
+++ b/scripts/activate-dns.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
+source ../.settings
+
 dns_host=$(echo $DOCKER_HOST | awk -F'[/:]' '{print $4}')
 
-kubectl --namespace=kube-system create -f - << EOF
+printf "${yellow}Activating DNS...${reset}\n"
+
+dns_cluster_ip=$(kubectl get services --namespace=kube-system kube-dns --template={{.spec.clusterIP}} 2> /dev/null)
+
+if [ -n "$dns_cluster_ip" ]; then
+	printf "\n${yellow}   ${warning} Kube DNS service already exists. ClusterIP: $dns_cluster_ip${reset}\n\n"
+	exit 0;
+fi
+
+kubectl --namespace=kube-system create -f  - << EOF > /dev/null
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -17,7 +28,7 @@ subsets:
     name: dns
 EOF
 
-kubectl --namespace=kube-system create -f - << EOF
+kubectl --namespace=kube-system create -f - << EOF > /dev/null
 kind: Service
 apiVersion: v1
 metadata:
@@ -30,3 +41,5 @@ spec:
     port: 53
     protocol: UDP
 EOF
+
+check_rc "Successfully started kube-dns" "Could not start kube-dns"

--- a/scripts/activate-dns.sh
+++ b/scripts/activate-dns.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ../.settings
+source ../common.sh
 
 dns_host=$(echo $DOCKER_HOST | awk -F'[/:]' '{print $4}')
 

--- a/scripts/activate-kube-ui.sh
+++ b/scripts/activate-kube-ui.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ../.settings
+source ../common.sh
 
 printf "${yellow}Activating Kube UI...${reset}\n"
 

--- a/scripts/docker-machine-add-route.sh
+++ b/scripts/docker-machine-add-route.sh
@@ -3,7 +3,7 @@
 # Set up routes for accessing services and DNS from MacOS
 
 # assume 'docker-vm' as the default docker machine name
-machine=${MACHINE_NAME:=docker-vm}
+machine=${DOCKER_MACHINE_VM_NAME:=docker-vm}
 docker_net=${DOCKER_MACHINE_NET:=10.0.0.0/16}
 
 rx='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'

--- a/scripts/docker-machine-add-route.sh
+++ b/scripts/docker-machine-add-route.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Set up routes for accessing services and DNS from MacOS
-source ../.settings
+source ../common.sh
 
 machine=$(docker-machine active)
 docker_net=${DOCKER_MACHINE_NET:=10.0.0.0/16}
@@ -12,7 +12,7 @@ function add_route {
 	machine_name=$1
 	docker_network=$2
 	docker_machine_ip=$(docker-machine ip $machine_name)
-	if [ $? -ne 0 ]; then 
+	if [ $? -ne 0 ]; then
 		exit -1;
 	fi
 
@@ -26,7 +26,7 @@ function add_route {
 			sudo route -n add $docker_network $docker_machine_ip
 			if [ $? -eq 0 ]; then
 				printf "\n${green}   ${checkmark} Successfully added route '$docker_net' -> '${docker_machine_ip}' ${reset}\n\n"
-			else 
+			else
 				printf "\n${error}   ${error} Cannot add route\n\n"
 			fi
 		elif [ "$existing_route_gateway" == "$docker_machine_ip" ]; then

--- a/scripts/docker-machine-add-route.sh
+++ b/scripts/docker-machine-add-route.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
 # Set up routes for accessing services and DNS from MacOS
+source ../.settings
 
-# assume 'docker-vm' as the default docker machine name
-#machine=${DOCKER_MACHINE_VM_NAME:=docker-vm}
 machine=$(docker-machine active)
 docker_net=${DOCKER_MACHINE_NET:=10.0.0.0/16}
 
@@ -17,19 +16,26 @@ function add_route {
 		exit -1;
 	fi
 
+	printf "${yellow}Checking routing entries for ${docker_net}...${reset}\n"
+
 	if [[ $docker_machine_ip =~ ^$rx\.$rx\.$rx\.$rx$ ]]; then
 		default_gateway=$(route -n get default | grep gateway | awk '{print $2}')
 		existing_route_gateway=$(route -n get $docker_network | grep gateway | awk '{print $2}')
 		if [ -z "$existing_route_gateway" ] || [ "$existing_route_gateway" == "$default_gateway" ]; then
-			echo "Adding route for docker-machine '$machine_name' and IP '$docker_machine_ip' requires sudo, please enter password"
+			printf "${yellow}Adding route for docker-machine '$machine_name' and IP '$docker_machine_ip' requires sudo, please enter password${reset}\n"
 			sudo route -n add $docker_network $docker_machine_ip
+			if [ $? -eq 0 ]; then
+				printf "\n${green}   ${checkmark} Successfully added route '$docker_net' -> '${docker_machine_ip}' ${reset}\n\n"
+			else 
+				printf "\n${error}   ${error} Cannot add route\n\n"
+			fi
 		elif [ "$existing_route_gateway" == "$docker_machine_ip" ]; then
-			echo "Route entry already exists"
+			printf "\n${yellow}   ${warning} Route entry already exists\n\n${reset}"
 		else
-			echo "Error: Existing route for $docker_network: $existing_route_gateway"
+			printf "\n${red}    ${error} Existing route for $docker_network: $existing_route_gateway\n\n${reset}"
 		fi
 	else
-		echo "No valid IP address for docker machine $machine_name: $docker_machine_ip"
+		printf "\n${red}   ${error} No valid IP address for docker machine $machine_name: $docker_machine_ip\n\n${reset}"
     fi
 }
 

--- a/scripts/docker-machine-add-route.sh
+++ b/scripts/docker-machine-add-route.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Set up routes for accessing services and DNS from MacOS
+
+# assume 'docker-vm' as the default docker machine name
+machine=${MACHINE_NAME:=docker-vm}
+docker_net=${DOCKER_MACHINE_NET:=10.0.0.0/16}
+
+rx='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
+
+function add_route {
+	machine_name=$1
+	docker_network=$2
+	docker_machine_ip=$(docker-machine ip $machine_name)
+	if [ $? -ne 0 ]; then 
+		exit -1;
+	fi
+
+	if [[ $docker_machine_ip =~ ^$rx\.$rx\.$rx\.$rx$ ]]; then
+		default_gateway=$(route -n get default | grep gateway | awk '{print $2}')
+		existing_route_gateway=$(route -n get $docker_network | grep gateway | awk '{print $2}')
+		if [ -z "$existing_route_gateway" ] || [ "$existing_route_gateway" == "$default_gateway" ]; then
+			echo "Adding route for docker-machine '$machine_name' and IP '$docker_machine_ip' requires sudo, please enter password"
+			sudo route -n add $docker_network $docker_machine_ip
+		elif [ "$existing_route_gateway" == "$docker_machine_ip" ]; then
+			echo "Route entry already exists"
+		else
+			echo "Error: Existing route for $docker_network: $existing_route_gateway"
+		fi
+	else
+		echo "No valid IP address for docker machine $machine_name: $docker_machine_ip"
+    fi
+}
+
+add_route $machine $docker_net

--- a/scripts/docker-machine-add-route.sh
+++ b/scripts/docker-machine-add-route.sh
@@ -3,7 +3,8 @@
 # Set up routes for accessing services and DNS from MacOS
 
 # assume 'docker-vm' as the default docker machine name
-machine=${DOCKER_MACHINE_VM_NAME:=docker-vm}
+#machine=${DOCKER_MACHINE_VM_NAME:=docker-vm}
+machine=$(docker-machine active)
 docker_net=${DOCKER_MACHINE_NET:=10.0.0.0/16}
 
 rx='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'

--- a/scripts/docker-machine-port-forwarding.sh
+++ b/scripts/docker-machine-port-forwarding.sh
@@ -2,9 +2,12 @@
 #
 # Set up kubectl port forwarding to boot2docker VM if needed.
 
+machine=${DOCKER_MACHINE_VM_NAME:=docker-vm}
+keyfile="~/.docker/machine/machines/$machine/id_rsa"
+
 function forward_port_if_not_forwarded {
     port=$1
-    forward_port_command="ssh -f -N -L $port:localhost:$port docker@$(docker-machine ip $(docker-machine active))"
+    forward_port_command="ssh -i $keyfile -f -N -L $port:localhost:$port docker@$(docker-machine ip $machine)"
     existing_forward=$(ps ax | grep "$forward_port_command" | grep -v grep)
     
     if [ -z "$existing_forward" ]; then

--- a/scripts/docker-machine-port-forwarding.sh
+++ b/scripts/docker-machine-port-forwarding.sh
@@ -4,15 +4,16 @@
 
 source ../.settings
 
-machine=$(docker-machine active)
-keyfile="$HOME/.docker/machine/machines/$machine/id_rsa"
-
 function forward_port_if_not_forwarded {
     port=$1
+
+    machine=$(docker-machine active)
+    keyfile="$HOME/.docker/machine/machines/$machine/id_rsa"
+
 	printf "${yellow}Checking forward for port '$port'${reset}\n"
     forward_port_command="ssh -i $keyfile -f -N -L $port:localhost:$port docker@$(docker-machine ip $machine)"
     existing_forward=$(ps ax | grep "$forward_port_command" | grep -v grep)
-    
+
     if [ -z "$existing_forward" ]; then
 		#printf "${yellow}Adding portforward for port '$port'${reset}\n"
         eval $forward_port_command &> /dev/null

--- a/scripts/docker-machine-port-forwarding.sh
+++ b/scripts/docker-machine-port-forwarding.sh
@@ -2,16 +2,23 @@
 #
 # Set up kubectl port forwarding to boot2docker VM if needed.
 
+source ../.settings
+
 machine=$(docker-machine active)
-keyfile="~/.docker/machine/machines/$machine/id_rsa"
+keyfile="$HOME/.docker/machine/machines/$machine/id_rsa"
 
 function forward_port_if_not_forwarded {
     port=$1
+	printf "${yellow}Checking forward for port '$port'${reset}\n"
     forward_port_command="ssh -i $keyfile -f -N -L $port:localhost:$port docker@$(docker-machine ip $machine)"
     existing_forward=$(ps ax | grep "$forward_port_command" | grep -v grep)
     
     if [ -z "$existing_forward" ]; then
-        eval $forward_port_command
+		#printf "${yellow}Adding portforward for port '$port'${reset}\n"
+        eval $forward_port_command &> /dev/null
+		check_rc "Successfully added port forward" "Could not forward port"
+	else
+		printf "\n${yellow}   ${warning} Port forward for '$port' already exists${reset}\n\n"
     fi
 }
 

--- a/scripts/docker-machine-port-forwarding.sh
+++ b/scripts/docker-machine-port-forwarding.sh
@@ -2,7 +2,7 @@
 #
 # Set up kubectl port forwarding to boot2docker VM if needed.
 
-source ../.settings
+source ../common.sh
 
 function forward_port_if_not_forwarded {
     port=$1

--- a/scripts/docker-machine-port-forwarding.sh
+++ b/scripts/docker-machine-port-forwarding.sh
@@ -2,7 +2,7 @@
 #
 # Set up kubectl port forwarding to boot2docker VM if needed.
 
-machine=${DOCKER_MACHINE_VM_NAME:=docker-vm}
+machine=$(docker-machine active)
 keyfile="~/.docker/machine/machines/$machine/id_rsa"
 
 function forward_port_if_not_forwarded {

--- a/scripts/start-docker-registry.sh
+++ b/scripts/start-docker-registry.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# starts a local Docker registry that can be used to make local images available to k8s
+
+function start_docker_registry {
+	action=$1
+	run_new_registry_cmd="docker run -d -p 5000:5000 --restart=always --name registry registry:2"
+	if [ $? -ne 0 ]; then
+		echo "docker command failed. Make sure that docker is running and shell environment is sane"
+		exit -1
+	fi
+
+	existing_registry=$(docker ps -a | grep registry:2 | awk '{print $1}')
+	run_existing_registry_cmd="docker start $existing_registry"
+	running_registry=$(docker ps | grep registry:2 | awk '{print $1}')
+	stop_registry_cmd="docker stop $running_registry"
+ 	case "$action" in
+		"start") 
+			if [ -z "$running_registry" ]; then
+				echo "Starting docker registry..."
+				if [ -z "$existing_registry" ]; then
+					eval $run_new_registry_command
+				else
+					echo "Using existing container: $existing_registry"
+					eval $run_existing_registry_cmd
+				fi
+			else
+				echo "Docker registry already running. Container ID: $running_registry"
+			fi
+			;;
+		"stop")
+			if [ -z "$existing_registry" ]; then
+				echo "Docker registry not running. Doing nothing"
+			else
+				echo "Shutting down docker registry. Container ID: $running_registry"
+				eval $stop_registry_cmd
+			fi
+			;;
+		"check")
+			if [ -n "$running_registry" ]; then
+				echo "Docker registry already running. Container ID: $running_registry"
+			elif [ -n "$existing_registry" ]; then
+				echo "Docker registry NOT running but container exists: $existing_registry"
+			fi
+			;;
+		*)
+			echo "Usage: docker_registry start|stop|check"
+			;;
+	esac
+}
+
+start_docker_registry $1

--- a/scripts/start-docker-registry.sh
+++ b/scripts/start-docker-registry.sh
@@ -2,7 +2,7 @@
 #
 # starts a local Docker registry that can be used to make local images available to k8s
 
-source ../.settings
+source ../common.sh
 
 function start_docker_registry {
 	action=$1
@@ -17,7 +17,7 @@ function start_docker_registry {
 	running_registry=$(docker ps | grep registry:2 | awk '{print $1}')
 	stop_registry_cmd="docker stop $running_registry"
  	case "$action" in
-		"start") 
+		"start")
 			printf "${yellow}Starting docker registry...${reset}\n"
 			if [ -z "$running_registry" ]; then
 				if [ -z "$existing_registry" ]; then

--- a/scripts/wait-for-kubernetes.sh
+++ b/scripts/wait-for-kubernetes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source ../.settings
+source ../common.sh
 
 printf "${yellow}Waiting for Kubernetes cluster to become available${reset}"
 

--- a/scripts/wait-for-kubernetes.sh
+++ b/scripts/wait-for-kubernetes.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-echo "Waiting for Kubernetes cluster to become available..."
+source ../.settings
+
+printf "${yellow}Waiting for Kubernetes cluster to become available${reset}"
 
 until $(kubectl cluster-info &> /dev/null); do
     sleep 1
+	printf "${yellow}.${reset}"
 done
 
-echo "Kubernetes cluster is up."
+printf "\n\n${green}   ${checkmark} Kubernetes cluster is up.${reset}\n\n"


### PR DESCRIPTION
This PR adds the following:
- a `.settings` script to enable/disable the k8s addons (DNS,UI) as well as other stuff (port forwarding, routes etc.)
- some reformatting and colors for the console output
- adds the google DNS servers to `skydns` so that you can use skydns for local name resolution
- a custom route entry to use skydns locally and interact with the k8s service via their DNS name
- a local Docker registry (can be controlled via `.settings`) to make local Docker images available to k8s (no need to push local images to dockerhub)

cheers
