### PR TITLE
Document minimum supported docker-machine version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On Linux we'll run Kubernetes using a local Docker Engine. You will also need Do
 
 ## Starting Kubernetes on OS X
 
-On OS X we'll launch Kubernetes inside a [boot2docker](http://boot2docker.io) VM via [Docker Machine](https://docs.docker.com/machine/). You will need to have Docker Machine, Docker Compose, and the kubectl tool installed locally. First start your boot2docker VM:
+On OS X we'll launch Kubernetes inside a [boot2docker](http://boot2docker.io) VM via [Docker Machine](https://docs.docker.com/machine/). You will need to have Docker Machine (v0.5.0 or newer), Docker Compose, and the kubectl tool installed locally. First start your boot2docker VM:
 
 ```sh
 docker-machine start <name>


### PR DESCRIPTION
I tried to use this with docker-machine v0.4.1 and [port forwarding setup](https://github.com/vyshane/docker-compose-kubernetes/blob/034e88963f6ce69bc3c054511c932d05e8c2a35d/scripts/docker-machine-port-forwarding.sh#L20) failed. [The release notes for docker-machine v0.5.0](https://github.com/docker/machine/releases/tag/v0.5.0) provide a hint:

> For instance, in this release we have added support for passing additional arguments when running a SSH command using Machine. This enables fun use cases like forwarding ports over SSH using the -L flag.

Note that I've only actually tested this successfully with v0.5.5, but if the release notes are to be believed then any v0.5.x should work.
